### PR TITLE
feat: only remote cluster will push builded artifact to dockerhub

### DIFF
--- a/app/src/bin/www.js
+++ b/app/src/bin/www.js
@@ -5,7 +5,7 @@ const port = 3000
 
 const requestHandler = (request, response) => {
   console.log(request.url)
-  response.end('Hello Node.js Server!')
+  response.end('Hello Node.js Server!!')
 }
 
 const server = http.createServer(requestHandler)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,6 @@ metadata:
   name: testci
 build:
   local:
-      push: true
       useDockerCLI: true
   artifacts:
   - image: docker.io/hiram1994/test-ci


### PR DESCRIPTION
Only remote k8s cluster case need to push built image to docker hub