### PR TITLE
fix: should use --experimental-modules flag to run es6 module

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,8 +12,8 @@
     "yarn": ">=1.2.0"
   },
   "scripts": {
-    "start": "node ./src/bin/www",
-    "dev": "nodemon ./src/bin/www",
+    "start": "node --experimental-modules ./src/bin/www",
+    "dev": "nodemon --experimental-modules ./src/bin/www",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint ./src",
     "test": "jest",

--- a/app/src/bin/www.js
+++ b/app/src/bin/www.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable no-plusplus */
-const http = require("http");
+import * as http from "http";
 
 const port = 3000;
 


### PR DESCRIPTION
## Description
> In previous PR, we add `type: module` in `package.json` to use ES6 module, but the app get error *Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /app/src/bin/www.js*.

After some research, I've found some causes:
- `www.js` use CommonJS require, instead it should use `import ... from ...` 
- Even use Node version 12+, now also need add a flag **--experimental-modules** after command **node**

## Some referece
- https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_introduction
- https://stackoverflow.com/questions/45854169/how-can-i-use-an-es6-import-in-node
- https://medium.com/@iamstan/tips-for-writing-es-modules-in-node-js-96ec688615a4