### PR TITLE
Feat/setup jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,57 @@
-node_modules
+# Logs
 logs
 *.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# nyc test coverage
+.nyc_output
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# Dependency directories
+node_modules/
+
+# TypeScript v1 declaration files
+typings/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+
+# JetBrains IDE hidden Files
+.idea
+
+# credentials
+src/config/credentials
+
+# OSX generated files
+**/.DS_Store
+
+# VS Code hidden files
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ before_install:
   && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
   && chmod +x skaffold && sudo mv skaffold /usr/local/bin/
--  bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" # for uploading coverage report to codecov
 install:
 - yarn --cwd ./app install
 script:
 - yarn --cwd ./app test:cvg
+- bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" # for uploading coverage report to codecov
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   chmod +x ./scripts/deploy_to_k8s.sh && ./scripts/deploy_to_k8s.sh; else

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ before_install:
   && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
   && chmod +x skaffold && sudo mv skaffold /usr/local/bin/
+-  bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" # for uploading coverage report to codecov
 install:
 - yarn --cwd ./app install
 script:
-- yarn --cwd ./app test
+- yarn --cwd ./app test:cvg
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  chmod +x ./scripts/deploy_to_k8s.sh && ./scripts/deploy_to_k8s.sh; else 
+  chmod +x ./scripts/deploy_to_k8s.sh && ./scripts/deploy_to_k8s.sh; else
   echo "Not merge operation to master branch, skip deploy..."; fi
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-## This is a github repository to test & setup CI
+[![Build Status](https://travis-ci.com/pihuilong/testCI.svg?branch=master)](https://travis-ci.com/pihuilong/testCI)
+[![codecov](https://codecov.io/gh/pihuilong/testCI/branch/master/graph/badge.svg)](https://codecov.io/gh/pihuilong/testCI)
+## This is a github repository to test & setup CI & setup basic steps for a future project

--- a/app/package.json
+++ b/app/package.json
@@ -5,15 +5,15 @@
   "repository": "",
   "license": "UNLICENSED",
   "private": true,
-  "type": "module",
+  "type": "commonjs",
   "engines": {
     "node": ">=8.7.0",
     "npm": ">=5.3.0",
     "yarn": ">=1.2.0"
   },
   "scripts": {
-    "start": "node --experimental-modules ./src/bin/www",
-    "dev": "nodemon --experimental-modules ./src/bin/www",
+    "start": "node ./src/bin/www",
+    "dev": "nodemon ./src/bin/www",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint ./src",
     "test": "jest",

--- a/app/package.json
+++ b/app/package.json
@@ -22,8 +22,7 @@
   "lint-staged": {
     "*.js": [
       "pretty-quick --staged",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "husky": {

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,20 @@
       "pre-push": "yarn test"
     }
   },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "<rootDir>/src/config"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/tests/setupTests.js"
+    ],
+    "testEnvironment": "node",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/src/drivers/",
+      "/__fixtures__/"
+    ]
+  },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",

--- a/app/src/bin/www.js
+++ b/app/src/bin/www.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable no-plusplus */
-import * as http from "http";
+const http = require("http");
 
 const port = 3000;
 

--- a/app/src/temp.js
+++ b/app/src/temp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  add: (a, b) => {
+    return a + b;
+  }
+};

--- a/app/src/tests/casual.test.js
+++ b/app/src/tests/casual.test.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-console */
+const { add } = require("../temp");
+
 describe("Empty test for test", () => {
-  it("should do nothing and pass", () => {
-    console.log("everything works fine...");
+  it("should return total of two numbers", () => {
+    const total = add(2, 3);
+
+    expect(total).toBe(5);
   });
 });

--- a/app/src/tests/setupTests.js
+++ b/app/src/tests/setupTests.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-console */
+console.log(
+  "A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed. Since setupFiles executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment."
+);
+console.log(
+  "Details see: https://jestjs.io/docs/en/configuration#setupfilesafterenv-array"
+);

--- a/scripts/deploy_to_k8s.sh
+++ b/scripts/deploy_to_k8s.sh
@@ -3,7 +3,6 @@
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 mkdir ${HOME}/.kube
 cp ./k8s/config.yaml ${HOME}/.kube/config
-cat ${HOME}/.kube/config
 cd ${HOME}/.kube
 sed -i 's/KUBE_CLUSTER_NAME/'"$KUBE_CLUSTER_NAME"'/g' config
 sed -i 's/KUBE_CLUSTER_CERTIFICATE/'"$KUBE_CLUSTER_CERTIFICATE"'/g' config


### PR DESCRIPTION
## DESCRIPTION
- Remove `git add` command in `lint-staged` since it will auto add this command from lint-staged v10 onwards.
- Setup jest config, such as `ignorePath`, `setupFile`, etc.
- Using `codecov.io` for online code coverage report.
- Add badge to README
- Edit package.json to use commonjs due to jest error with ESM. May consider use babel-like tools to use ES6 syntax.

## REFERENCE
- https://jestjs.io/docs/en/configuration
- https://docs.codecov.io/docs